### PR TITLE
Handle next bowl after spare and add tests for strikes

### DIFF
--- a/Bowling.java
+++ b/Bowling.java
@@ -107,12 +107,9 @@ class Scoreboard {
 			totalPoints += currentFrameTotal;
     }
     
-    Optional<Frame> previousFrameOpt = previousFrame();
-    if (previousFrameOpt.isPresent()) {
-      Frame previousFrame = previousFrameOpt.get();
-      if (previousFrame.isSpare()) {
-        totalPoints += previousFrame.getFrameScore() + getCurrentFrame().firstBowl();
-      }
+    Optional<Frame> previousFrame = previousFrame();
+    if (previousFrame.isPresent() && previousFrame.get().isSpare()) {
+      totalPoints += previousFrame.get().getFrameScore() + getCurrentFrame().firstBowl();
     }
 	}
 

--- a/Bowling.java
+++ b/Bowling.java
@@ -54,7 +54,7 @@ class Frame {
 
 class Scoreboard {
 
-	private LinkedList<Frame> allFrames;
+	private List<Frame> allFrames;
 	private Integer totalPoints;
 
 	public Scoreboard() {

--- a/Bowling.java
+++ b/Bowling.java
@@ -49,6 +49,10 @@ class Frame {
 	public Boolean isFull() {
 		return frameScores[0] != null && frameScores[1] != null ? true : false;
 	}
+  
+  public Boolean isSpare() {
+    return getFrameScore() == 10;
+  }
 
 }
 
@@ -97,16 +101,17 @@ class Scoreboard {
   }
 
 	private void updateTotalPoints() {
-		Integer currentFrameTotal = getCurrentFrame().getFrameScore();
-		if (currentFrameTotal != 10)
-				totalPoints += currentFrameTotal;
+    Frame currentFrame = getCurrentFrame();
+    if (!currentFrame.isSpare()) {
+      Integer currentFrameTotal = currentFrame.getFrameScore();
+			totalPoints += currentFrameTotal;
+    }
     
-    Optional<Frame> previousFrame = previousFrame();
-    if (previousFrame.isPresent()) {
-      Integer previousFrameTotal = previousFrame.get().getFrameScore();
-
-      if (previousFrameTotal == 10) {
-        totalPoints += previousFrameTotal + getCurrentFrame().firstBowl();
+    Optional<Frame> previousFrameOpt = previousFrame();
+    if (previousFrameOpt.isPresent()) {
+      Frame previousFrame = previousFrameOpt.get();
+      if (previousFrame.isSpare()) {
+        totalPoints += previousFrame.getFrameScore() + getCurrentFrame().firstBowl();
       }
     }
 	}

--- a/Bowling.java
+++ b/Bowling.java
@@ -41,6 +41,10 @@ class Frame {
 		Integer totalFrameScore = frameScores[0] + frameScores[1];
 		return totalFrameScore;
 	}
+  
+  public Integer firstBowl() {
+    return frameScores[0];
+  }
 
 	public Boolean isFull() {
 		return frameScores[0] != null && frameScores[1] != null ? true : false;
@@ -87,6 +91,13 @@ class Scoreboard {
 		Integer currentFrameTotal = getCurrentFrame().getFrameScore();
 		if (currentFrameTotal != 10)
 				totalPoints += currentFrameTotal;
+    
+    if (allFrames.size() > 1) {
+      Integer previousFrameTotal = allFrames.get(allFrames.size()-2).getFrameScore();
+      if (previousFrameTotal == 10) {
+        totalPoints += previousFrameTotal + getCurrentFrame().firstBowl();
+      }
+    }
 	}
 
 }

--- a/Bowling.java
+++ b/Bowling.java
@@ -86,14 +86,25 @@ class Scoreboard {
 		Frame currentFrame = allFrames.get(lastIndex);
 		return currentFrame;
 	}
+  
+  private Optional<Frame> previousFrame() {
+    if (allFrames.size() > 1) {
+      int nextToLastIndex = allFrames.size() - 2;
+      return Optional.of(allFrames.get(nextToLastIndex));
+    }
+    
+    return Optional.empty();
+  }
 
 	private void updateTotalPoints() {
 		Integer currentFrameTotal = getCurrentFrame().getFrameScore();
 		if (currentFrameTotal != 10)
 				totalPoints += currentFrameTotal;
     
-    if (allFrames.size() > 1) {
-      Integer previousFrameTotal = allFrames.get(allFrames.size()-2).getFrameScore();
+    Optional<Frame> previousFrame = previousFrame();
+    if (previousFrame.isPresent()) {
+      Integer previousFrameTotal = previousFrame.get().getFrameScore();
+
       if (previousFrameTotal == 10) {
         totalPoints += previousFrameTotal + getCurrentFrame().firstBowl();
       }

--- a/Bowling.java
+++ b/Bowling.java
@@ -41,18 +41,18 @@ class Frame {
 		Integer totalFrameScore = frameScores[0] + frameScores[1];
 		return totalFrameScore;
 	}
-  
-  public Integer firstBowl() {
-    return frameScores[0];
-  }
+	
+	public Integer firstBowl() {
+		return frameScores[0];
+	}
 
 	public Boolean isFull() {
 		return frameScores[0] != null && frameScores[1] != null ? true : false;
 	}
-  
-  public Boolean isSpare() {
-    return getFrameScore() == 10;
-  }
+	
+	public Boolean isSpare() {
+		return getFrameScore() == 10;
+	}
 
 }
 
@@ -90,27 +90,27 @@ class Scoreboard {
 		Frame currentFrame = allFrames.get(lastIndex);
 		return currentFrame;
 	}
-  
-  private Optional<Frame> previousFrame() {
-    if (allFrames.size() > 1) {
-      int nextToLastIndex = allFrames.size() - 2;
-      return Optional.of(allFrames.get(nextToLastIndex));
-    }
-    
-    return Optional.empty();
-  }
+	
+	private Optional<Frame> previousFrame() {
+		if (allFrames.size() > 1) {
+			int nextToLastIndex = allFrames.size() - 2;
+			return Optional.of(allFrames.get(nextToLastIndex));
+		}
+		
+		return Optional.empty();
+	}
 
 	private void updateTotalPoints() {
-    Frame currentFrame = getCurrentFrame();
-    if (!currentFrame.isSpare()) {
-      Integer currentFrameTotal = currentFrame.getFrameScore();
+		Frame currentFrame = getCurrentFrame();
+		if (!currentFrame.isSpare()) {
+			Integer currentFrameTotal = currentFrame.getFrameScore();
 			totalPoints += currentFrameTotal;
-    }
-    
-    Optional<Frame> previousFrame = previousFrame();
-    if (previousFrame.isPresent() && previousFrame.get().isSpare()) {
-      totalPoints += previousFrame.get().getFrameScore() + getCurrentFrame().firstBowl();
-    }
+		}
+		
+		Optional<Frame> previousFrame = previousFrame();
+		if (previousFrame.isPresent() && previousFrame.get().isSpare()) {
+			totalPoints += previousFrame.get().getFrameScore() + getCurrentFrame().firstBowl();
+		}
 	}
 
 }

--- a/Bowling.java
+++ b/Bowling.java
@@ -72,22 +72,22 @@ class Scoreboard {
 		}
 	}
 
-	public void addFrame() {
+	public Integer getScore() {
+		return totalPoints;
+	}
+
+	private void addFrame() {
 		Frame frame = new Frame();
 		allFrames.add(frame);
 	}
 
-	public Frame getCurrentFrame() {
+	private Frame getCurrentFrame() {
 		int lastIndex = allFrames.size() - 1;
 		Frame currentFrame = allFrames.get(lastIndex);
 		return currentFrame;
 	}
 
-	public Integer getScore() {
-		return totalPoints;
-	}
-
-	public void updateTotalPoints() {
+	private void updateTotalPoints() {
 		Integer currentFrameTotal = getCurrentFrame().getFrameScore();
 		if (currentFrameTotal != 10)
 				totalPoints += currentFrameTotal;

--- a/BowlingTest.java
+++ b/BowlingTest.java
@@ -89,5 +89,16 @@ public class BowlingTest {
 		
 		assertEquals(6, score);
 	}
+	
+	@Test
+	public void shouldScoreStrikeFrameAfterNextTwoBallsForSingleFrame() throws Exception {
+		bowling.bowl(4).bowl(2)
+			.bowl(10)
+			.bowl(4).bowl(2);
+		
+		int score = bowling.score();
+		
+		assertEquals(28, score);
+	}
 
 }

--- a/BowlingTest.java
+++ b/BowlingTest.java
@@ -79,5 +79,15 @@ public class BowlingTest {
 
 		assertEquals(26, score);
 	}
+	
+	@Test
+	public void shouldOutputScoreOfPreviousFramesAfterAStrike() throws Exception {
+		bowling.bowl(4).bowl(2)
+			.bowl(10);
+		
+		int score = bowling.score();
+		
+		assertEquals(6, score);
+	}
 
 }


### PR DESCRIPTION
Had a significant amount of refactoring after the initial hack of a solution.  I'd suggest looking at each commit and seeing if they seem a good break down of things to you.

Some thoughts:
- Wanted `update()` to score the spare, but couldn't find a good path to it...yet.  I even considered building up the score each time instead of maintaining it.  In then end we should discuss that more.
- Also, should we score a spare Frame as soon as the next ball is thrown or always wait until the next Frame is done being bowled?
- I don't like the `firstBowl()` method.  Since we should add the next ball after a spare it seems we should ask the `Scoreboard` for the next ball for a given Frame?
- Optional is noisier than I'd like, but I think it's the right choice - just might need a better pattern for use.
- LinkedList works, but typically ArrayList is used - consider [this analysis](https://stackoverflow.com/questions/322715/when-to-use-linkedlist-over-arraylist#322742) of them (though realize that it's not that big of deal in our case)