### PR TITLE
Scored a turkey

### DIFF
--- a/Bowling.java
+++ b/Bowling.java
@@ -74,6 +74,8 @@ class Frame {
 
 class Scoreboard {
 
+	private static final int strikePoints = 10;
+	private static final int sparePoints = 10;
 	private List<Frame> allFrames;
 	private Integer totalPoints;
 	private Optional<Frame> previousFrame;
@@ -154,22 +156,15 @@ class Scoreboard {
 		if (previousFrame.isPresent()) 
 			previousPreviousFrame = previousFrame(previousFrame.get());
 
-		if (!currentFrame.isSpare() && !currentFrame.isStrike()) {
-			Integer currentFrameTotal = currentFrame.getFrameScore();
-			totalPoints += currentFrameTotal;
-		}
+		if (!currentFrame.isSpare() && !currentFrame.isStrike())
+			totalPoints += currentFrame.getFrameScore();
 
-		if (previousFrame.isPresent() && previousFrame.get().isSpare() ) {
-			totalPoints += previousFrame.get().getFrameScore() + 
-						   currentFrame().firstBowl();
-		} else if (isTurkey()) {
-			totalPoints += previousPreviousFrame.get().getFrameScore() + 
-						   previousFrame.get().getFrameScore() + 
-						   currentFrame().firstBowl();
-		} else if (isSingleStrike()) {
-			totalPoints += previousFrame.get().getFrameScore() + 
-			   	 		   currentFrame().getFrameScore();
-		}
+		if (previousFrame.isPresent() && previousFrame.get().isSpare())
+			totalPoints += sparePoints + currentFrame().firstBowl();
+		else if (isTurkey())
+			totalPoints += strikePoints * 3;
+		else if (isSingleStrike())
+			totalPoints += strikePoints + currentFrame().getFrameScore();
 	}
 
 }

--- a/Bowling.java
+++ b/Bowling.java
@@ -39,10 +39,12 @@ class Frame {
 	}
 
 	public void update(Integer pinsDown) {
-		if (frameScores[0] == null)
+		if (frameScores[0] == null) {
 			frameScores[0] = pinsDown;
-		else if (frameScores[1] == null)
+		}
+		else if (frameScores[1] == null) {
 			frameScores[1] = pinsDown;
+		}
 	}
 
 	public Integer getFrameScore() {
@@ -74,8 +76,8 @@ class Frame {
 
 class Scoreboard {
 
-	private static final int strikePoints = 10;
-	private static final int sparePoints = 10;
+	private static final int STRIKE_POINTS = 10;
+	private static final int SPARE_POINTS = 10;
 	private List<Frame> allFrames;
 	private Integer totalPoints;
 	private Optional<Frame> secondToLastFrame;
@@ -89,11 +91,17 @@ class Scoreboard {
 	}
 
 	public void update(Integer pinsDown) {
-		Frame currentFrame = getCurrentFrame();
+		currentFrame = getCurrentFrame();
+		secondToLastFrame = getFrameBefore(currentFrame);
+		if (secondToLastFrame.isPresent()) {
+			thirdToLastFrame = getFrameBefore(secondToLastFrame.get());
+		}
+
 		currentFrame.update(pinsDown);
 
-		if (currentFrame.isStrike())
+		if (currentFrame.isStrike()) {
 			currentFrame.update(0);
+		}
 
 		if (currentFrame.isFull()) {
 			updateTotalPoints();
@@ -123,12 +131,12 @@ class Scoreboard {
 	private Optional<Frame> getFrameBefore(Frame frame) {
 		int currentIndex = allFrames.indexOf(frame);
 		int lastIndex = allFrames.size() - 1;
+		int nextToLastIndex = allFrames.size() - 2;
+		int thirdToLastIndex = allFrames.size() - 3;
 
 		if (allFrames.size() > 1 && currentIndex == lastIndex) {
-			int nextToLastIndex = allFrames.indexOf(frame) - 1;
 			return Optional.of(allFrames.get(nextToLastIndex));
-		} else if (allFrames.size() > 2) {
-			int thirdToLastIndex = allFrames.size() - 3;
+		} else if (allFrames.size() > 2 && currentIndex == nextToLastIndex) {
 			return Optional.of(allFrames.get(thirdToLastIndex));
 		}
 		
@@ -150,20 +158,17 @@ class Scoreboard {
 	}
 
 	private void updateTotalPoints() {
-		currentFrame = getCurrentFrame();
-		secondToLastFrame = getFrameBefore(currentFrame);
-		if (secondToLastFrame.isPresent()) 
-			thirdToLastFrame = getFrameBefore(secondToLastFrame.get());
-
-		if (!currentFrame.isSpare() && !currentFrame.isStrike())
+		if (!currentFrame.isSpare() && !currentFrame.isStrike()) {
 			totalPoints += currentFrame.getFrameScore();
+		}
 
-		if (secondToLastFrame.isPresent() && secondToLastFrame.get().isSpare())
-			totalPoints += sparePoints + getCurrentFrame().firstBowl();
-		else if (isTurkey())
-			totalPoints += strikePoints * 3;
-		else if (isSingleStrike())
-			totalPoints += strikePoints + getCurrentFrame().getFrameScore();
+		if (secondToLastFrame.isPresent() && secondToLastFrame.get().isSpare()) {
+			totalPoints += SPARE_POINTS + getCurrentFrame().firstBowl();
+		} else if (isTurkey()) {
+			totalPoints += STRIKE_POINTS * 3;
+		} else if (isSingleStrike()) {
+			totalPoints += STRIKE_POINTS + getCurrentFrame().getFrameScore();
+		}
 	}
 
 }

--- a/Bowling.java
+++ b/Bowling.java
@@ -78,8 +78,8 @@ class Scoreboard {
 	private static final int sparePoints = 10;
 	private List<Frame> allFrames;
 	private Integer totalPoints;
-	private Optional<Frame> previousFrame;
-	private Optional<Frame> previousPreviousFrame;
+	private Optional<Frame> secondToLastFrame;
+	private Optional<Frame> thirdToLastFrame;
 	private Frame currentFrame;
 
 	public Scoreboard() {
@@ -89,12 +89,11 @@ class Scoreboard {
 	}
 
 	public void update(Integer pinsDown) {
-		Frame currentFrame = currentFrame();
+		Frame currentFrame = getCurrentFrame();
 		currentFrame.update(pinsDown);
 
-		if (currentFrame.isStrike()) {
+		if (currentFrame.isStrike())
 			currentFrame.update(0);
-		}
 
 		if (currentFrame.isFull()) {
 			updateTotalPoints();
@@ -115,13 +114,13 @@ class Scoreboard {
 		allFrames.add(frame);
 	}
 
-	private Frame currentFrame() {
+	private Frame getCurrentFrame() {
 		int lastIndex = allFrames.size() - 1;
 		Frame currentFrame = allFrames.get(lastIndex);
 		return currentFrame;
 	}
 	
-	private Optional<Frame> previousFrame(Frame frame) {
+	private Optional<Frame> getFrameBefore(Frame frame) {
 		int currentIndex = allFrames.indexOf(frame);
 		int lastIndex = allFrames.size() - 1;
 
@@ -138,33 +137,33 @@ class Scoreboard {
 
 	private Boolean isTurkey() {
 		return currentFrame.isStrike() &&
-			   previousFrame.isPresent() && 
-			   previousFrame.get().isStrike() && 
-			   previousPreviousFrame.isPresent() && 
-			   previousPreviousFrame.get().isStrike();
+			   secondToLastFrame.isPresent() && 
+			   secondToLastFrame.get().isStrike() && 
+			   thirdToLastFrame.isPresent() && 
+			   thirdToLastFrame.get().isStrike();
 	}
 
 	private Boolean isSingleStrike() {
-		return previousFrame.isPresent() && 
-		       previousFrame.get().isStrike() && 
+		return secondToLastFrame.isPresent() && 
+		       secondToLastFrame.get().isStrike() && 
 		       !currentFrame.isStrike();
 	}
 
 	private void updateTotalPoints() {
-		currentFrame = currentFrame();
-		previousFrame = previousFrame(currentFrame);
-		if (previousFrame.isPresent()) 
-			previousPreviousFrame = previousFrame(previousFrame.get());
+		currentFrame = getCurrentFrame();
+		secondToLastFrame = getFrameBefore(currentFrame);
+		if (secondToLastFrame.isPresent()) 
+			thirdToLastFrame = getFrameBefore(secondToLastFrame.get());
 
 		if (!currentFrame.isSpare() && !currentFrame.isStrike())
 			totalPoints += currentFrame.getFrameScore();
 
-		if (previousFrame.isPresent() && previousFrame.get().isSpare())
-			totalPoints += sparePoints + currentFrame().firstBowl();
+		if (secondToLastFrame.isPresent() && secondToLastFrame.get().isSpare())
+			totalPoints += sparePoints + getCurrentFrame().firstBowl();
 		else if (isTurkey())
 			totalPoints += strikePoints * 3;
 		else if (isSingleStrike())
-			totalPoints += strikePoints + currentFrame().getFrameScore();
+			totalPoints += strikePoints + getCurrentFrame().getFrameScore();
 	}
 
 }

--- a/BowlingTest.java
+++ b/BowlingTest.java
@@ -13,7 +13,6 @@ public class BowlingTest {
 		bowling = new Bowling();
 	}
 
-	// @Ignore
 	@Test
 	public void shouldOutputAScoreGivenOneFrame() throws Exception {
 		bowling.bowl(2);
@@ -22,7 +21,6 @@ public class BowlingTest {
 		assertEquals(5, score);
 	}
 
-	// @Ignore
 	@Test
 	public void shouldOutputScoreForEmptyGame() throws Exception {
 		bowling.bowl(0).bowl(0)
@@ -40,7 +38,6 @@ public class BowlingTest {
 		assertEquals(0, score);
 	}
 
-	// @Ignore
 	@Test
 	public void shouldThrowIllegalArgumentExceptionWhenPinsDownIsNegative() throws Exception {
 		try {
@@ -51,8 +48,7 @@ public class BowlingTest {
 			assertEquals(message, iae.getMessage());
 		}
 	}
-	
-	// @Ignore	
+		
 	@Test
 	public void shouldNotTotalScoreForAFrameWithASpare() throws Exception {
 		bowling.bowl(5).bowl(5);
@@ -62,7 +58,6 @@ public class BowlingTest {
 		assertEquals(0, score);
 	}
 
-	// @Ignore
 	@Test
 	public void shouldOutputScoreOfPreviousFramesAfterASpare() throws Exception {
 		bowling.bowl(2).bowl(7)
@@ -74,7 +69,6 @@ public class BowlingTest {
 		assertEquals(15, score);
 	}
 
-	// @Ignore
 	@Test
 	public void shouldIncludeSpareScoreAfterNextNonSpareNonStrikeFrame() throws Exception {
 		bowling.bowl(3).bowl(5)
@@ -85,8 +79,7 @@ public class BowlingTest {
 
 		assertEquals(26, score);
 	}
-
-	// @Ignore	
+	
 	@Test
 	public void shouldOutputScoreOfPreviousFramesAfterAStrike() throws Exception {
 		bowling.bowl(4).bowl(2)
@@ -96,8 +89,7 @@ public class BowlingTest {
 		
 		assertEquals(6, score);
 	}
-
-	// @Ignore	
+	
 	@Test
 	public void shouldScoreStrikeFrameAfterNextTwoBallsForSingleFrame() throws Exception {
 		bowling.bowl(4).bowl(2)
@@ -109,7 +101,6 @@ public class BowlingTest {
 		assertEquals(28, score);
 	}
 	
-	// @Ignore
 	@Test
 	public void shouldScoreStrikeAfterNextTwoStrikes() throws Exception {
 		bowling.bowl(10)
@@ -121,7 +112,6 @@ public class BowlingTest {
 		assertEquals(30, score);
 	}
 
-	// @Ignore
 	@Test
 	public void shouldScoreTwoStrikesAfterNonSpareNonStrikeFrame() throws Exception {
 		bowling.bowl(10)
@@ -134,7 +124,6 @@ public class BowlingTest {
 		assertEquals(45, score);
 	}
 
-	// @Ignore
 	@Test
 	public void shouldOutputScoreboardFrameByFrame() throws Exception {
 		bowling.bowl(1).bowl(2)

--- a/BowlingTest.java
+++ b/BowlingTest.java
@@ -13,6 +13,7 @@ public class BowlingTest {
 		bowling = new Bowling();
 	}
 
+	// @Ignore
 	@Test
 	public void shouldOutputAScoreGivenOneFrame() throws Exception {
 		bowling.bowl(2);
@@ -21,6 +22,7 @@ public class BowlingTest {
 		assertEquals(5, score);
 	}
 
+	// @Ignore
 	@Test
 	public void shouldOutputScoreForEmptyGame() throws Exception {
 		bowling.bowl(0).bowl(0)
@@ -38,6 +40,7 @@ public class BowlingTest {
 		assertEquals(0, score);
 	}
 
+	// @Ignore
 	@Test
 	public void shouldThrowIllegalArgumentExceptionWhenPinsDownIsNegative() throws Exception {
 		try {
@@ -49,6 +52,7 @@ public class BowlingTest {
 		}
 	}
 	
+	// @Ignore	
 	@Test
 	public void shouldNotTotalScoreForAFrameWithASpare() throws Exception {
 		bowling.bowl(5).bowl(5);
@@ -58,6 +62,7 @@ public class BowlingTest {
 		assertEquals(0, score);
 	}
 
+	// @Ignore
 	@Test
 	public void shouldOutputScoreOfPreviousFramesAfterASpare() throws Exception {
 		bowling.bowl(2).bowl(7)
@@ -69,6 +74,7 @@ public class BowlingTest {
 		assertEquals(15, score);
 	}
 
+	// @Ignore
 	@Test
 	public void shouldIncludeSpareScoreAfterNextNonSpareNonStrikeFrame() throws Exception {
 		bowling.bowl(3).bowl(5)
@@ -79,7 +85,8 @@ public class BowlingTest {
 
 		assertEquals(26, score);
 	}
-	
+
+	// @Ignore	
 	@Test
 	public void shouldOutputScoreOfPreviousFramesAfterAStrike() throws Exception {
 		bowling.bowl(4).bowl(2)
@@ -89,7 +96,8 @@ public class BowlingTest {
 		
 		assertEquals(6, score);
 	}
-	
+
+	// @Ignore	
 	@Test
 	public void shouldScoreStrikeFrameAfterNextTwoBallsForSingleFrame() throws Exception {
 		bowling.bowl(4).bowl(2)
@@ -101,6 +109,7 @@ public class BowlingTest {
 		assertEquals(28, score);
 	}
 	
+	// @Ignore
 	@Test
 	public void shouldScoreStrikeAfterNextTwoStrikes() throws Exception {
 		bowling.bowl(10)
@@ -112,6 +121,20 @@ public class BowlingTest {
 		assertEquals(30, score);
 	}
 
+	// @Ignore
+	@Test
+	public void shouldScoreTwoStrikesAfterNonSpareNonStrikeFrame() throws Exception {
+		bowling.bowl(10)
+			.bowl(10)
+			.bowl(5)
+			.bowl(0);
+		
+		int score = bowling.score();
+		
+		assertEquals(45, score);
+	}
+
+	// @Ignore
 	@Test
 	public void shouldOutputScoreboardFrameByFrame() throws Exception {
 		bowling.bowl(1).bowl(2)


### PR DESCRIPTION
I updated previousFrame() that returned an Optional to be getFrameBefore() which now takes a Frame as an argument. We talked about previousPreviousFrame being awkward. What do you think about these naming conventions? 

Also, what do you think about using sparePoints and strikePoints "constants" to clean up the updateTotalPoints if/else statement?

I was thinking about one point you brought up earlier: updating the score after every bowl or every Frame. I think the way we have it now is how it works in real life (see the attachment), but you seem more familiar with Bowling rules than I, so tell me if I'm wrong.

![bowlingscoreboardexample](https://user-images.githubusercontent.com/19984330/28494040-c616928e-6ef0-11e7-92b9-7058faa2e355.jpg)

