### PR TITLE
End of game no extra bowl

### DIFF
--- a/Bowling.java
+++ b/Bowling.java
@@ -10,7 +10,9 @@ public class Bowling {
 	}
 
 	public Bowling bowl(Integer pinsDown) {
-		if (pinsDown < 0) {
+		if (scoreboard.isGameOver()) {
+			throw new IllegalArgumentException("You cannot bowl more in a completed game.");
+		} else if (pinsDown < 0) {
 			throw new IllegalArgumentException("Cannot knock down negative pins. Bowl again.");
 		}
 		scoreboard.update(pinsDown);
@@ -115,6 +117,14 @@ class Scoreboard {
 
 	public Integer getScore() {
 		return totalPoints;
+	}
+
+	public Boolean isGameOver() {
+		currentFrame = getCurrentFrame();
+		secondToLastFrame = getFrameBefore(currentFrame);
+		return allFrames.size() == 11 && 
+			   !secondToLastFrame.get().isStrike() && 
+			   !secondToLastFrame.get().isSpare();
 	}
 
 	private void addFrame() {

--- a/Bowling.java
+++ b/Bowling.java
@@ -93,12 +93,6 @@ class Scoreboard {
 	}
 
 	public void update(Integer pinsDown) {
-		currentFrame = getCurrentFrame();
-		secondToLastFrame = getFrameBefore(currentFrame);
-		if (secondToLastFrame.isPresent()) {
-			thirdToLastFrame = getFrameBefore(secondToLastFrame.get());
-		}
-
 		currentFrame.update(pinsDown);
 
 		if (currentFrame.isStrike()) {
@@ -122,6 +116,10 @@ class Scoreboard {
 	public Boolean isGameOver() {
 		currentFrame = getCurrentFrame();
 		secondToLastFrame = getFrameBefore(currentFrame);
+		if (secondToLastFrame.isPresent()) {
+			thirdToLastFrame = getFrameBefore(secondToLastFrame.get());
+		}
+		
 		return allFrames.size() == 11 && 
 			   !secondToLastFrame.get().isStrike() && 
 			   !secondToLastFrame.get().isSpare();

--- a/Bowling.java
+++ b/Bowling.java
@@ -161,6 +161,13 @@ class Scoreboard {
 			   thirdToLastFrame.get().isStrike();
 	}
 
+	private Boolean isDoubleStrike() {
+		return secondToLastFrame.isPresent() && 
+			   secondToLastFrame.get().isStrike() && 
+			   thirdToLastFrame.isPresent() && 
+			   thirdToLastFrame.get().isStrike();
+	}
+
 	private Boolean isSingleStrike() {
 		return secondToLastFrame.isPresent() && 
 		       secondToLastFrame.get().isStrike() && 
@@ -173,35 +180,17 @@ class Scoreboard {
 		if (!currentFrame.isSpare() && !currentFrame.isStrike()) {
 			totalPoints += currentFrame.getFrameScore();
 		}
-		
-		if (secondToLastFrame.isPresent()) {
-			if (secondToLastFrame.get().isSpare()) {
-				totalPoints += secondToLastFrame.get().getFrameScore() + currentFrame.firstBowl();
-			} else if (secondToLastFrame.get().isStrike()) {
-				if (!currentFrame.isStrike()) {
-					// if the current frame isn't a strike than score it, otherwise we need to wait for another bowl.
-					totalPoints += secondToLastFrame.get().getFrameScore() + currentFrame.getFrameScore();
-				}
-				if (thirdToLastFrame.isPresent() && thirdToLastFrame.get().isStrike()) {
-					totalPoints += thirdToLastFrame.get().getFrameScore() + secondToLastFrame.get().getFrameScore() + currentFrame.firstBowl();
-				}
-			}
-		}
 
-		/*
 		if (secondToLastFrame.isPresent() && secondToLastFrame.get().isSpare()) {
 			totalPoints += SPARE_POINTS + getCurrentFrame().firstBowl();
 		} else if (isTurkey()) {
 			totalPoints += STRIKE_POINTS * 3;
-		} else if (isSingleStrike()) {
-			totalPoints += STRIKE_POINTS + getCurrentFrame().getFrameScore();
-		} else if (secondToLastFrame.isPresent() && secondToLastFrame.get().isStrike()
-							&& thirdToLastFrame.isPresent() && thirdToLastFrame.get().isStrike()) {
-								System.out.println("scoring...");
+		} else if (isDoubleStrike()) {
 			totalPoints += STRIKE_POINTS * 2 + getCurrentFrame().firstBowl();
 			totalPoints += STRIKE_POINTS + getCurrentFrame().getFrameScore();
+		} else if (isSingleStrike()) {
+			totalPoints += STRIKE_POINTS + getCurrentFrame().getFrameScore();
 		}
-		*/
 	}
 
 }

--- a/Bowling.java
+++ b/Bowling.java
@@ -120,9 +120,7 @@ class Scoreboard {
 			thirdToLastFrame = getFrameBefore(secondToLastFrame.get());
 		}
 		
-		return allFrames.size() == 11 && 
-			   !secondToLastFrame.get().isStrike() && 
-			   !secondToLastFrame.get().isSpare();
+		return allFrames.size() == 11;
 	}
 
 	private void addFrame() {

--- a/BowlingTest.java
+++ b/BowlingTest.java
@@ -145,6 +145,28 @@ public class BowlingTest {
 		}
 	}
 
+	@Test 
+	public void shouldPreventRecordingExtraBowlAfterPerfectGame() throws Exception {
+		bowling.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10);
+		try {
+			bowling.bowl(5);
+			fail("IllegalArgumentException should have been thrown.");
+		} catch (IllegalArgumentException iae) {
+			assertEquals("You cannot bowl more in a completed game.", iae.getMessage());
+		}	
+	}
+
 	@Test
 	public void shouldOutputScoreboardFrameByFrame() throws Exception {
 		bowling.bowl(1).bowl(2)


### PR DESCRIPTION
To be frank, I worked on this on Friday and meant to come back to review it with more time. As I mentioned, however, I'm running around at the last minute before our trip. Nonetheless, I wanted to make sure to toss this back your way before leaving.

I merged the last pull request, handled the no extra bowl test, refactored `updateTotalPoints` method, moved the frame variables, added a test for no extra bowl after a perfect game, and thought briefly about our next direction. We were talking about the separation between something that holds the `pinsDown` per frame and something that holds the score per frame. Seeing as the `pinsDown` per frame is something the user should be able to see, seems like we should write tests for this (as opposed to just refactoring after handling some other test), yes? 

Lastly, I had to move `currentFrame` and `secondToLastFrame` in order to be defined in the `isGameOver` method (I moved `thirdToLastFrame` just to keep them together). We talked about this being bad practice because we have to remember where they live if we need to move them. What are options and trade offs you see with handling these particular variables?