### PR TITLE
Print totals

### DIFF
--- a/Bowling.java
+++ b/Bowling.java
@@ -24,10 +24,16 @@ public class Bowling {
 	}
 
 	public String printScoreboard() {
-		return scoreboard.getFrames().stream()
+		String pinsDown = scoreboard.getFrames().stream()
 			.filter(Frame::isFull)
 			.map(Frame::printFrame)
-			.collect(Collectors.joining(","));
+			.collect(Collectors.joining("|"));
+
+		String scores = scoreboard.getAllTotals().stream()
+			.map(s -> String.format("%3s", s))
+			.collect(Collectors.joining("|"));
+
+		return String.format("|%s|\n|%s|", pinsDown, scores);
 	}
 
 }
@@ -74,7 +80,7 @@ class Frame {
 	}
 
 	public String printFrame() {
-		return String.format("[%d,%d]", frameScores[0], frameScores[1]);
+		return String.format("%d,%d", frameScores[0], frameScores[1]);
 	}
 }
 
@@ -93,7 +99,10 @@ class FinalFrame extends Frame {
 	}
 	
 	public Integer getFrameScore() {
-		Integer totalFrameScore = frameScores[0] + frameScores[1] + frameScores[2];
+		Integer totalFrameScore = frameScores[0] + frameScores[1];
+		if (frameScores[2] != null) {
+			totalFrameScore += frameScores[2];
+		}
 		return totalFrameScore;
 	}
 
@@ -123,11 +132,13 @@ class Scoreboard {
 	private static final int STRIKE_POINTS = 10;
 	private static final int SPARE_POINTS = 10;
 	private List<Frame> allFrames;
+	private List<Integer> allTotals;
 	private Integer totalPoints;
 
 	public Scoreboard() {
 		totalPoints = 0;
 		allFrames = new ArrayList<>();
+		allTotals = new ArrayList<>();
 		addFrame();
 	}
 
@@ -140,7 +151,8 @@ class Scoreboard {
 		}
 
 		if (currentFrame().isFull()) {
-			
+			allTotals.add(totalPoints);
+
 			if (allFrames.size() == 9) {
 				addFinalFrame();
 			} else if (allFrames.size() < 9) {
@@ -154,7 +166,11 @@ class Scoreboard {
 	}
 
 	public Integer getScore() {
-		return totalPoints;
+ 		return totalPoints;
+	}
+
+	public List<Integer> getAllTotals() {
+		return Collections.unmodifiableList(allTotals);
 	}
 
 	public Boolean isGameOver() {		
@@ -240,6 +256,8 @@ class Scoreboard {
 			} else if (finalFrame.currentBowl() == 2) {
 				if (secondToLastFrame().get().isStrike() && finalFrame.isStrike(1) && finalFrame.isStrike(2)) {
 					totalPoints += STRIKE_POINTS * 3;
+				} else if (finalFrame.getFrameScore() < 10) {
+					totalPoints += finalFrame.getFrameScore();
 				}
 			} else if (finalFrame.currentBowl() == 3) {
 				if (finalFrame.isStrike(1) && finalFrame.isStrike(2) && finalFrame.isStrike(3)) {
@@ -255,5 +273,4 @@ class Scoreboard {
 			}
 		}
 	}	
-
 }

--- a/Bowling.java
+++ b/Bowling.java
@@ -24,92 +24,84 @@ public class Bowling {
 	}
 
 	public String printScoreboard() {
-		String pinsDown = scoreboard.getFrames().stream()
+		String pinsDownRecord = scoreboard.getFrames().stream()
 			.filter(Frame::isFull)
 			.map(Frame::printFrame)
 			.collect(Collectors.joining("|"));
 
-		String scores = scoreboard.getAllTotals().stream()
-			.map(s -> String.format("%3s", s))
+		String scoresRecord = scoreboard.getPointsList().stream()
+			.map(score -> String.format("%3s", score))
 			.collect(Collectors.joining("|"));
 
-		return String.format("|%s|\n|%s|", pinsDown, scores);
+		return String.format("|%s|\n|%s|", pinsDownRecord, scoresRecord);
 	}
 
 }
 
 class Frame {
 
-	protected Integer[] frameScores;
+	Integer[] allBowls;
 
 	public Frame() {
-		frameScores = new Integer[2];
+		allBowls = new Integer[2];
 	}
 
 	public void update(Integer pinsDown) {
 		int index = 0;
-		while (index < frameScores.length) {
-			if (frameScores[index] == null) {
-				frameScores[index] = pinsDown;
+		while (index < allBowls.length) {
+			if (allBowls[index] == null) {
+				allBowls[index] = pinsDown;
 				break;
 			}
 			index++;
 		}
 	}
 
-	public Integer getFrameScore() {
-		Integer totalFrameScore = frameScores[0] + frameScores[1];
-		return totalFrameScore;
+	public Integer getTotalPinsDown() {
+		return Arrays.stream(allBowls)
+			.filter(Objects::nonNull)
+			.reduce(0, Integer::sum);
 	}
 	
-	public Integer getBowl(Integer bowl) {
-		bowl -= 1;
-		return frameScores[bowl];
+	public Integer getPinsDownOnBowl(Integer bowl) {
+		return allBowls[bowl - 1];
 	}
 
 	public Boolean isFull() {
-		return frameScores[0] != null && frameScores[1] != null;
+		return allBowls[0] != null && allBowls[1] != null;
 	}
 	
 	public Boolean isSpare() {
-		return getFrameScore() == 10 && getBowl(1) != 10;
+		return getTotalPinsDown() == 10 && getPinsDownOnBowl(1) != 10;
 	}
 
 	public Boolean isStrike() {
-		return getBowl(1) == 10;
+		return getPinsDownOnBowl(1) == 10;
 	}
 
 	public String printFrame() {
-		return String.format("%d,%d", frameScores[0], frameScores[1]);
+		return String.format("%d,%d", allBowls[0], allBowls[1]);
 	}
 }
 
 class FinalFrame extends Frame {
 
 	public FinalFrame() {
-		frameScores = new Integer[3];
+		allBowls = new Integer[3];
 	}
 
 	public Integer currentBowl() {
 		int index = 0;
-		while (index < frameScores.length && frameScores[index] != null) {
+		while (index < allBowls.length && allBowls[index] != null) {
 			index++;
 		}
 		return index;
 	}
-	
-	public Integer getFrameScore() {
-		Integer totalFrameScore = frameScores[0] + frameScores[1];
-		if (frameScores[2] != null) {
-			totalFrameScore += frameScores[2];
-		}
-		return totalFrameScore;
-	}
 
 	public Boolean isFull() {
-		if (frameScores[0] != null && frameScores[1] != null) {
-			if (frameScores[0] + frameScores[1] >= 10) {
-				return frameScores[2] != null;
+		if (allBowls[0] != null && allBowls[1] != null) {
+			if (allBowls[0] + allBowls[1] >= 10) {
+				return allBowls[2] != null;
 			} else {
 				return true;
 			}
@@ -118,11 +110,11 @@ class FinalFrame extends Frame {
 	}
 	
 	public Boolean isSpare() {
-		return !isStrike(1) && (frameScores[0] + frameScores[1] == 10);
+		return !isStrike(1) && (allBowls[0] + allBowls[1] == 10);
 	}
 
 	public Boolean isStrike(Integer bowl) {
-		return getBowl(bowl) == 10;
+		return getPinsDownOnBowl(bowl) == 10;
 	}
 
 }
@@ -131,14 +123,14 @@ class Scoreboard {
 
 	private static final int STRIKE_POINTS = 10;
 	private static final int SPARE_POINTS = 10;
-	private List<Frame> allFrames;
-	private List<Integer> allTotals;
+	private List<Frame> allFramesList;
+	private List<Integer> allPointsList;
 	private Integer totalPoints;
 
 	public Scoreboard() {
 		totalPoints = 0;
-		allFrames = new ArrayList<>();
-		allTotals = new ArrayList<>();
+		allFramesList = new ArrayList<>();
+		allPointsList = new ArrayList<>();
 		addFrame();
 	}
 
@@ -151,26 +143,28 @@ class Scoreboard {
 		}
 
 		if (currentFrame().isFull()) {
-			allTotals.add(totalPoints);
+			allPointsList.add(totalPoints);
 
-			if (allFrames.size() == 9) {
-				addFinalFrame();
-			} else if (allFrames.size() < 9) {
-				addFrame();
+			if (!isFinalFrame()) {
+				if (allFramesList.size() == 9) {
+					addFinalFrame();
+				} else {
+					addFrame();
+				}
 			}
 		}
 	}
 	
 	public List<Frame> getFrames() {
-		return Collections.unmodifiableList(allFrames);
+		return Collections.unmodifiableList(allFramesList);
 	}
 
 	public Integer getScore() {
  		return totalPoints;
 	}
 
-	public List<Integer> getAllTotals() {
-		return Collections.unmodifiableList(allTotals);
+	public List<Integer> getPointsList() {
+		return Collections.unmodifiableList(allPointsList);
 	}
 
 	public Boolean isGameOver() {		
@@ -178,39 +172,39 @@ class Scoreboard {
 	}
 	
 	public Boolean isFinalFrame() {
-		return currentFrame() instanceof FinalFrame;
+		return allFramesList.size() == 10;
 	}
 	
 	private void addFrame() {
 		Frame frame = new Frame();
-		allFrames.add(frame);
+		allFramesList.add(frame);
 	}
 
 	private void addFinalFrame() {
 		Frame frame = new FinalFrame();
-		allFrames.add(frame);
+		allFramesList.add(frame);
 	}
 
 	private Frame currentFrame() {
-		int lastIndex = allFrames.size() - 1;
-		return allFrames.get(lastIndex);
+		int lastIndex = allFramesList.size() - 1;
+		return allFramesList.get(lastIndex);
 	}
 
 	private Optional<Frame> secondToLastFrame() {
-		int secondToLastIndex = allFrames.size() - 2;
+		int secondToLastIndex = allFramesList.size() - 2;
 
 		return getFrameByIndex(secondToLastIndex);
 	}
 
 	private Optional<Frame> thirdToLastFrame() {
-		int thirdToLastIndex = allFrames.size() - 3;
+		int thirdToLastIndex = allFramesList.size() - 3;
 
 		return getFrameByIndex(thirdToLastIndex);
 	}
 	
 	private Optional<Frame> getFrameByIndex(int index) {
 		if (index >= 0) {
-			return Optional.of(allFrames.get(index));
+			return Optional.of(allFramesList.get(index));
 		}
 		return Optional.empty();
 	}
@@ -237,14 +231,14 @@ class Scoreboard {
 
 	private void scoreBonusBowls() {
 		if (secondToLastFrame().isPresent() && secondToLastFrame().get().isSpare() && !currentFrame().isFull()) {
-			totalPoints += SPARE_POINTS + currentFrame().getBowl(1);
+			totalPoints += SPARE_POINTS + currentFrame().getPinsDownOnBowl(1);
 		} else if (isTurkey()) {
 			totalPoints += STRIKE_POINTS * 3;
 		} else if (isDoubleStrike() && currentFrame().isFull()) {
-			totalPoints += STRIKE_POINTS * 2 + currentFrame().getBowl(1);
-			totalPoints += STRIKE_POINTS + currentFrame().getFrameScore();
+			totalPoints += STRIKE_POINTS * 2 + currentFrame().getPinsDownOnBowl(1);
+			totalPoints += STRIKE_POINTS + currentFrame().getTotalPinsDown();
 		} else if (isSingleStrike() && currentFrame().isFull()) {
-			totalPoints += STRIKE_POINTS + currentFrame().getFrameScore();
+			totalPoints += STRIKE_POINTS + currentFrame().getTotalPinsDown();
 		}
 	}
 
@@ -256,20 +250,20 @@ class Scoreboard {
 			} else if (finalFrame.currentBowl() == 2) {
 				if (secondToLastFrame().get().isStrike() && finalFrame.isStrike(1) && finalFrame.isStrike(2)) {
 					totalPoints += STRIKE_POINTS * 3;
-				} else if (finalFrame.getFrameScore() < 10) {
-					totalPoints += finalFrame.getFrameScore();
+				} else if (finalFrame.getTotalPinsDown() < 10) {
+					totalPoints += finalFrame.getTotalPinsDown();
 				}
 			} else if (finalFrame.currentBowl() == 3) {
 				if (finalFrame.isStrike(1) && finalFrame.isStrike(2) && finalFrame.isStrike(3)) {
 					totalPoints += STRIKE_POINTS * 3;
 				} else if (finalFrame.isSpare()) {
-					totalPoints += finalFrame.getFrameScore();
+					totalPoints += finalFrame.getTotalPinsDown();
 				}
 			}
 		} else {
 			scoreBonusBowls();
 			if (currentFrame().isFull() && !currentFrame().isSpare()) {
-				totalPoints += currentFrame().getFrameScore();
+				totalPoints += currentFrame().getTotalPinsDown();
 			}
 		}
 	}	

--- a/BowlingTest.java
+++ b/BowlingTest.java
@@ -223,7 +223,30 @@ public class BowlingTest {
 		
 		assertEquals(300, score);
 	}
-	
+
+	@Test
+	public void shouldOutputScoreboardFrameByFrameWithForPerfectGame() throws Exception {
+		bowling.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10)
+			.bowl(10);
+
+			String expectedScoreboard =
+				"|10,0|10,0|10,0|10,0|10,0|10,0|10,0|10,0|10,0|10,10,10|\n" +
+				"| 30| 60| 90|120|150|180|210|240|270|300|";
+			String actualScoreboard = bowling.printScoreboard();
+
+			assertEquals(expectedScoreboard, actualScoreboard);
+	}
+
 	@Test
 	public void shouldOutputScoreboardFrameByFrame() throws Exception {
 		bowling.bowl(1).bowl(2)
@@ -237,12 +260,12 @@ public class BowlingTest {
 			.bowl(3).bowl(2)
 			.bowl(1).bowl(0);
 
-			String expectedScoreboard =
+		String expectedScoreboard = 
 				"|1,2|3,4|5,4|3,2|1,0|1,2|3,4|5,4|3,2|1,0|\n" +
 				"|  3| 10| 19| 24| 25| 28| 35| 44| 49| 50|";
-			String actualScoreboard = bowling.printScoreboard();
+		String actualScoreboard = bowling.printScoreboard();
 
-			assertEquals(expectedScoreboard, actualScoreboard);
+		assertEquals(expectedScoreboard, actualScoreboard);
 	}
 
 }

--- a/BowlingTest.java
+++ b/BowlingTest.java
@@ -22,6 +22,23 @@ public class BowlingTest {
 	}
 	
 	@Test
+	public void shouldOutputScoreForGameWithNoBonusBowls() throws Exception {
+		bowling.bowl(6).bowl(3)
+			.bowl(4).bowl(3)
+			.bowl(2).bowl(2)
+			.bowl(5).bowl(3)
+			.bowl(3).bowl(4)
+			.bowl(1).bowl(8)
+			.bowl(6).bowl(2)
+			.bowl(0).bowl(3)
+			.bowl(6).bowl(1)
+			.bowl(2).bowl(0);
+
+		int score = bowling.score();
+		assertEquals(64, score);
+	}
+
+	@Test
 	public void shouldOutputScoreForEmptyGame() throws Exception {
 		bowling.bowl(0).bowl(0)
 			.bowl(0).bowl(0)
@@ -221,7 +238,7 @@ public class BowlingTest {
 			.bowl(1).bowl(0);
 
 			String expectedScoreboard =
-				"|1,2|3,4|5,4|3,2|1,0|1,2|3,4|5,4|3,2|1,0|" +
+				"|1,2|3,4|5,4|3,2|1,0|1,2|3,4|5,4|3,2|1,0|\n" +
 				"|  3| 10| 19| 24| 25| 28| 35| 44| 49| 50|";
 			String actualScoreboard = bowling.printScoreboard();
 


### PR DESCRIPTION
You were right: our issue was in `updateTotalPoints()` as we have not covered all game-ending scenarios yet.

Summary:
- Added a test to score a game with no bonus bowls and that was not empty. It passed.

- Updated several naming conventions to better suit having both a record of `pinsDown` and a record of `totalPoints`.

- Updated `getTotalPinsDown()` so that it worked for both an instance of `Frame` and `FinalFrame`. (Flexed some stream muscles -- although I'm not sure if this was appropriate due to its length being so short).

- Addressed several of your suggestions from my previous pull request:
--> I think using `size()` to define `isFinalFrame()` is more clear 
--> I cleaned up the if/else statement within `Scoreboard.update()` -- is this what you were getting at?

- Added a test to print the Scoreboard more accurately: 3 bowls on the final frame and scores appearing under the proper frame as they would in a real bowling game. I wasn't planning on going here, but I felt it was the best next test in order to save us from unnecessary struggles with `updateTotalPoints()`.

Other:
- In order to be more like an actual bowling game, we could print the `pinsDownRecord` with 'X's and '/' later.